### PR TITLE
[COMPASS-1922] Migrate actions from internal-package query to the external plugin.

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -1,10 +1,91 @@
 import Reflux from 'reflux';
 
 const QueryBarActions = Reflux.createActions([
-  /**
-   * define your actions as strings below, for example:
+/**
+   * toggles or sets the expanded query options open or closed.
    */
-  'toggleStatus'
+  'toggleQueryOptions': {sync: true},
+  /**
+   * toggles or sets sample true/false
+   */
+  'toggleSample': {sync: true},
+  /**
+   * Sets the entire query, overwriting all fields.
+   */
+  'setQuery': {sync: true},
+  /**
+   * Sets the entire query as string, overwriting all fields.
+   */
+  'setQueryString': {sync: true},
+  /**
+   * Sets the entire query as string, overwriting all fields, and detects
+   * if the user is still typing. Useful for text input.
+   */
+  'typeQueryString': {sync: true},
+  /**
+   * Sets the value for a specific field, overwriting all previous values.
+   */
+  'setValue': {sync: true},
+  /**
+   * Clears the value of a specific field.
+   */
+  'clearValue': {sync: true},
+
+  /* Distinct actions:
+   * support single values (equality clause) and multiple values ($in clause).
+   */
+
+  /**
+   * Adds a value to a distinct set of values for a field.
+   */
+  'addDistinctValue': {sync: true},
+  /**
+   * Removes a value from a distinct set of values for a field.
+   */
+  'removeDistinctValue': {sync: true},
+  /**
+   * Toggles a value in a distinct set of values for a field.
+   */
+  'toggleDistinctValue': {sync: true},
+  /**
+   * Sets all distinct values of a field at once. If a single value is specified
+   * and the value is already set, remove the value.
+   */
+  'setDistinctValues': {sync: true},
+
+  /* Range actions:
+   * support single values (equality clause) and ranges ($gt(e) / $lt(e) clauses).
+   */
+
+  /**
+   * Sets a range of values, specifying min and max values and inclusive/exclusive
+   * upper and lower bounds.
+   */
+  'setRangeValues': {sync: true},
+
+  /* Geo actions */
+
+  /**
+   *  sets a $geoWithin query with center and distance.
+   */
+  'setGeoWithinValue': {sync: true},
+
+  /* Execution */
+
+  /**
+   * apply the current query, only possible if the query is valid. Also stores
+   * the current query as `lastExecutedQuery`.
+   */
+  'apply': {sync: true},
+  /**
+   * return to the last executed query, dismissing all changes.
+   */
+  'reset': {sync: true},
+
+  /**
+   * Refresh the code mirror instance.
+   */
+  'refreshCodeMirror': { sync: true }
 ]);
 
 export default QueryBarActions;

--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,10 @@ import QueryBarStore from 'stores';
 /**
  * A sample role for the component.
  */
-const ROLE = {
-  name: 'QueryBar',
-  component: QueryBarPlugin
-};
+// const ROLE = {
+//   name: 'QueryBar',
+//   component: QueryBarPlugin
+// };
 
 /**
  * Activate all the components in the Query Bar package.
@@ -24,8 +24,8 @@ function activate(appRegistry) {
   //   - CollectionHUD.Item
   //   - Header.Item
 
-  appRegistry.registerRole('', ROLE);
-  appRegistry.registerAction('QueryBar.Actions', QueryBarActions);
+  // appRegistry.registerRole('', ROLE);
+  appRegistry.registerAction('Query.Actions', QueryBarActions);
   appRegistry.registerStore('QueryBar.Store', QueryBarStore);
 }
 
@@ -34,8 +34,8 @@ function activate(appRegistry) {
  * @param {Object} appRegistry - The Hadron appRegisrty to deactivate this plugin with.
  **/
 function deactivate(appRegistry) {
-  appRegistry.deregisterRole('', ROLE);
-  appRegistry.deregisterAction('QueryBar.Actions');
+  // appRegistry.deregisterRole('', ROLE);
+  appRegistry.deregisterAction('Query.Actions');
   appRegistry.deregisterStore('QueryBar.Store');
 }
 


### PR DESCRIPTION
- Migrated the existing query internal-package actions to the new external plugin
- Updated the `index.js` to correctly register the actions under the correct namespace `Query` (in order to be backwards compatible)
- Temp comment out the Role registration of the plugin template until it is known whether this is needed or not.