### PR TITLE
always display resetbtn

### DIFF
--- a/src/components/query-bar/query-bar.jsx
+++ b/src/components/query-bar/query-bar.jsx
@@ -317,7 +317,7 @@ class QueryBar extends Component {
       'btn-default',
       'btn-sm',
       styles['reset-button'],
-      { [ styles['is-visible'] ]: queryState === 'apply'}
+      { disabled: queryState !== 'apply'}
     );
 
     return (

--- a/src/components/query-bar/query-bar.less
+++ b/src/components/query-bar/query-bar.less
@@ -87,10 +87,5 @@
 }
 
 .reset-button {
-  display: none !important;
   margin-left: 5px;
-
-  &.is-visible {
-    display: inline-block !important;
-  }
 }


### PR DESCRIPTION
always show the reset button, but until the query is applied, have it in `disabled` state. Something like this: 
![tghlxngdqh](https://user-images.githubusercontent.com/8107784/42086613-f0d630c8-7b93-11e8-8ea4-9e1ddec9d386.gif)
