### PR TITLE
COMPASS-3107: add 85% width to ace editor

### DIFF
--- a/src/components/option-editor/option-editor.jsx
+++ b/src/components/option-editor/option-editor.jsx
@@ -133,7 +133,7 @@ class OptionEditor extends Component {
       <AceEditor
         mode="mongodb"
         theme="mongodb-query"
-        width="100%"
+        width="85%"
         value={this.props.value}
         onChange={this.onChangeQuery}
         editorProps={{ $blockScrolling: Infinity }}


### PR DESCRIPTION
Longer queries in the query bar get covered by the options button. Get editor width to be shorter so user can see the end of the query when they scroll over to the end o/