### PR TITLE
hide print margin in ace editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5714,7 +5714,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "requires": {
         "duplexer": "~0.1.1",

--- a/src/components/option-editor/option-editor.jsx
+++ b/src/components/option-editor/option-editor.jsx
@@ -21,6 +21,7 @@ const OPTIONS = {
   minLines: 1,
   maxLines: 1,
   highlightActiveLine: false,
+  showPrintMargin: false,
   showGutter: false,
   useWorker: false
 };


### PR DESCRIPTION
## Context
Remember that lil tini-tiny-can-only-see-under-the-looking-glass-but-still-really-annoying line in our query bar editor?

Well It's no more!

*Before*:
<img width="1157" alt="Screen Shot 2019-08-06 at 13 22 26" src="https://user-images.githubusercontent.com/8107784/62537285-55546700-b850-11e9-8c48-4bf8d0a755da.png">

*After*:
<img width="1273" alt="Screen Shot 2019-08-06 at 13 48 35" src="https://user-images.githubusercontent.com/8107784/62537580-0d820f80-b851-11e9-9fd3-dac66dfa3217.png">



## Semver
Patch