### PR TITLE
COMPASS-3905: Query History bar disappear by switching to a different collection

### DIFF
--- a/src/components/query-bar/query-bar.jsx
+++ b/src/components/query-bar/query-bar.jsx
@@ -116,10 +116,6 @@ class QueryBar extends Component {
     hasFocus: false
   }
 
-  componentWillUnmount() {
-    this.props.store.localAppRegistry.emit('collapse-query-history');
-  }
-
   onChange(label, evt) {
     const type = OPTION_DEFINITION[label].type;
     const { actions } = this.props;


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description

Stop emitting `collapse-query-history` when the  query bar unmount as that closes the query history also on tab switch.

NOTE: it does not fix the case where the collection is open in the same tab.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
