### PR TITLE
COMPASS-4245: reset does not clear out query bar fields

### DIFF
--- a/src/stores/query-bar-store.js
+++ b/src/stores/query-bar-store.js
@@ -692,7 +692,6 @@ const configureStore = (options = {}) => {
         newState.autoPopulated = true;
         this.setState(omit(newState, 'expanded'));
       }
-      options.actions.refreshEditor();
     },
 
     storeDidUpdate(prevState) {

--- a/test/renderer/query-bar-store.spec.js
+++ b/test/renderer/query-bar-store.spec.js
@@ -608,13 +608,13 @@ describe('QueryBarStore [Store]', function() {
           expect(store.state.filterString).to.be.equal('');
 
           unsubscribe = store.listen(state => {
-            expect(state.filterString).to.be.equal('{filter: invalid}');
+            expect(state.filterString).to.be.equal('not valid');
             expect(state.filterValid).to.be.false;
             expect(state.filter).to.deep.equal({});
             done();
           });
 
-          store.setQueryString('filter', '{filter: invalid}');
+          store.setQueryString('filter', 'not valid');
         });
       });
 


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description

Calling `refreshEditor` on `reset` was overwriting the query options using `aceEditor` with the previous value.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

How to add a test for this?

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

The following packages are dependent:

- '@mongodb-js/compass'
- '@mongodb-js/compass-crud'
- '@mongodb-js/compass-explain-plan'
- '@mongodb-js/compass-schema'
- '@mongodb-js/compass-home'
- '@mongodb-js/compass-collection'

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
