### PR TITLE
COMPASS-4389: Allow resizing in the query options

### DIFF
--- a/src/components/option-editor/option-editor.jsx
+++ b/src/components/option-editor/option-editor.jsx
@@ -19,7 +19,7 @@ const OPTIONS = {
   useSoftTabs: true,
   fontSize: 11,
   minLines: 1,
-  maxLines: 1,
+  maxLines: 10,
   highlightActiveLine: false,
   showPrintMargin: false,
   showGutter: false,

--- a/src/components/option-editor/option-editor.jsx
+++ b/src/components/option-editor/option-editor.jsx
@@ -4,6 +4,8 @@ import AceEditor from 'react-ace';
 import ace from 'brace';
 import { QueryAutoCompleter } from 'mongodb-ace-autocompleter';
 
+import styles from './option-editor.less';
+
 import 'brace/ext/language_tools';
 import 'mongodb-ace-mode';
 import 'mongodb-ace-theme-query';
@@ -112,6 +114,7 @@ class OptionEditor extends Component {
   render() {
     return (
       <AceEditor
+        className={styles['option-editor']}
         mode="mongodb"
         theme="mongodb-query"
         width="80%"

--- a/src/components/option-editor/option-editor.less
+++ b/src/components/option-editor/option-editor.less
@@ -1,0 +1,3 @@
+.option-editor {
+  align-self: center;
+}

--- a/src/components/option-editor/option-editor.spec.js
+++ b/src/components/option-editor/option-editor.spec.js
@@ -3,6 +3,8 @@ import { mount } from 'enzyme';
 import OptionEditor from 'components/option-editor';
 import configureActions from 'actions';
 
+import styles from './option-editor.less';
+
 describe('OptionEditor [Component]', function() {
   let onChangeSpy;
   let onApplySpy;
@@ -39,6 +41,10 @@ describe('OptionEditor [Component]', function() {
 
     it('renders the editor', function() {
       expect(component.find('#query-bar-option-input-Apply')).to.be.present();
+    });
+
+    it('has the correct class', function() {
+      expect(component.find(`.${styles['option-editor']}`)).to.be.present();
     });
   });
 });

--- a/src/components/query-option/query-option.less
+++ b/src/components/query-option/query-option.less
@@ -3,8 +3,8 @@
 .component {
   display: flex;
   align-items: center;
-  height: 28px;
-  padding: 0 5px;
+  min-height: 28px;
+  padding: 4px 5px;
   border-top: 1px solid @gray7;
   overflow: scroll;
   width: 100%;

--- a/src/components/query-option/query-option.less
+++ b/src/components/query-option/query-option.less
@@ -2,7 +2,6 @@
 
 .component {
   display: flex;
-  align-items: center;
   min-height: 28px;
   padding: 4px 5px;
   border-top: 1px solid @gray7;
@@ -44,6 +43,7 @@
   font-family: "Akzidenz", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 11px;
   flex-grow: 0;
+  display: table;
 
   // TODO: CSS-modules on Info Sprinkle styles in dependency repo
   :global {


### PR DESCRIPTION
COMPASS-4389

This PR adds resizing to the query bar fields to make hopefully make querying and finding documents easier.

___
**current behavior**
![current behavior small res](https://user-images.githubusercontent.com/1791149/90411025-6ebb0080-e0ab-11ea-9d79-385068654b88.gif)


**what this pr does**
![new behavior low res](https://user-images.githubusercontent.com/1791149/90411141-9ad68180-e0ab-11ea-8cf7-a512d13b45e2.gif)


*max length (after 10 we scroll)*
![too many lines](https://user-images.githubusercontent.com/1791149/90411113-90b48300-e0ab-11ea-9967-a258f016fbe0.gif)


*with a sort*
![big query with a sort](https://user-images.githubusercontent.com/1791149/90411007-65319880-e0ab-11ea-9229-153b2b5f0949.gif)
