### PR TITLE
feat: add placeholders for fields COMPASS-4616

### DIFF
--- a/src/components/option-editor/option-editor.jsx
+++ b/src/components/option-editor/option-editor.jsx
@@ -39,6 +39,7 @@ class OptionEditor extends Component {
     value: PropTypes.any,
     onChange: PropTypes.func,
     onApply: PropTypes.func,
+    placeholder: PropTypes.string,
     schemaFields: PropTypes.array
   };
 
@@ -126,6 +127,7 @@ class OptionEditor extends Component {
         onFocus={() => {
           tools.setCompleters([ this.completer ]);
         }}
+        placeholder={this.props.placeholder}
         onLoad={(editor) => {
           this.editor = editor;
           this.editor.setBehavioursEnabled(true);

--- a/src/components/query-option/query-option.jsx
+++ b/src/components/query-option/query-option.jsx
@@ -81,7 +81,9 @@ class QueryOption extends Component {
         onApply={this.props.onApply}
         autoPopulated={this.props.autoPopulated}
         actions={this.props.actions}
-        schemaFields={this.props.schemaFields} />
+        schemaFields={this.props.schemaFields}
+        placeholder={this.props.placeholder}
+      />
     );
   }
 

--- a/src/stores/query-bar-store.js
+++ b/src/stores/query-bar-store.js
@@ -445,7 +445,7 @@ const configureStore = (options = {}) => {
     },
 
     /**
-     * takes either a single value or an array of values, and sets the value on
+     * Takes either a single value or an array of values, and sets the value on
      * the filter correctly as equality or $in depending on the number of values.
      *
      * @param {Object} args   arguments must include `field` and `value`:
@@ -483,7 +483,7 @@ const configureStore = (options = {}) => {
     },
 
     /**
-     * adds a discrete value to a field on the filter, converting primitive
+     * Adds a discrete value to a field on the filter, converting primitive
      * values to $in lists as required.
      *
      * @param {Object} args    object with a `field` and `value` key.


### PR DESCRIPTION
Looks like we already had the placeholders, they just weren't passed through.

<img width="280" alt="Screen Shot 2021-02-10 at 2 38 24 AM" src="https://user-images.githubusercontent.com/1791149/107452167-0f651700-6b49-11eb-9625-f3016ac49610.png">
