### PR TITLE
feat(sort): Show an example of an array sort value in placeholder COMPASS-4258

### DIFF
--- a/src/components/query-bar/query-bar.jsx
+++ b/src/components/query-bar/query-bar.jsx
@@ -36,7 +36,7 @@ const OPTION_DEFINITION = {
   },
   sort: {
     type: 'document',
-    placeholder: '{ field: -1 }',
+    placeholder: "{ field: -1 } or [['field', -1]]",
     link: 'https://docs.mongodb.com/manual/reference/method/cursor.sort/'
   },
   collation: {


### PR DESCRIPTION
We are planning to allow arrays in sort query option and want to show an example of usage in sort field placeholder:

<img width="290" alt="image" src="https://user-images.githubusercontent.com/5036933/112845672-68f7b580-90a5-11eb-91b5-db89a348c717.png">
